### PR TITLE
fix crash if template changes

### DIFF
--- a/pyernluefter/__init__.py
+++ b/pyernluefter/__init__.py
@@ -31,13 +31,13 @@ RELEASE_URL = {
 
 def repl_to_parse(m: re.Match):
     # prepend a v s.t. no variable begins with an underscore
-    return "{{v{}}}".format(m.group(1))
+    return f"{{v{m.group(1)}}}"
 
 
 def construct_url(ip_address: str) -> str:
     """Construct the URL with a given IP address."""
     if "http://" not in ip_address and "https://" not in ip_address:
-        ip_address = "{}{}".format("http://", ip_address)
+        ip_address = f"http://{ip_address}"
     ip_address = ip_address.rstrip("/")
     return ip_address
 
@@ -81,7 +81,7 @@ class Bayernluefter:
         }
 
     async def _request_bl(self, target):
-        url = "{}{}".format(self.url, target)
+        url = f"{self.url}{target}"
         async with self._session.get(url) as response:
             if response.status != HTTPStatus.OK:
                 raise ValueError("Server does not support Bayernluefter protocol.")


### PR DESCRIPTION
If the user uploads a new template to the device while this package is
already running, it crashes with the following error:
`File "/config/custom_components/bayernluefter/init.py", line 96, in _async_update_data
await self._device.update()
File "/usr/local/lib/python3.11/site-packages/pyernluefter/init.py", line 74, in update
parse_dict = parse.parse(self.template, state).named`

This commit discards the outdated template, which causes that a new
template will be fetched with the next update.